### PR TITLE
Fixed missing JETTY_BASE when running with a separate data container

### DIFF
--- a/jetty/9.2.7.v20150116/jetty-entrypoint.sh
+++ b/jetty/9.2.7.v20150116/jetty-entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 
 run_jetty() {
+    mkdir -p $JETTY_BASE
+
     if [ $# -eq 0 ] && [ ! -f $JETTY_BASE/start.ini ]; then
         java -jar $JETTY_HOME/start.jar --add-to-start=http,deploy,jsp,jstl,annotations,logging jetty.base=$JETTY_BASE && \
         java -jar $JETTY_HOME/start.jar --add-to-startd=http jetty.base=$JETTY_BASE


### PR DESCRIPTION
When you start a jetty container, the JETTY_BASE volume exists. This was
created during building of the docker image. However, when using a separate
data volume container, this folder does not necessarily exist.

To ensure that this folder exists when the jetty container starts, we
create the folder before checking for the existence of the config files.

Signed-off-by: logitrix dannyberrdia@gmail.com
